### PR TITLE
feat(worldgen): Added depth parameter to the Aether

### DIFF
--- a/Forge/src/main/resources/data/aeroblender/worldgen/density_function/aether/depth.json
+++ b/Forge/src/main/resources/data/aeroblender/worldgen/density_function/aether/depth.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:add",
+  "argument1": {
+    "type": "minecraft:y_clamped_gradient",
+    "from_value": 1.5,
+    "from_y": 0,
+    "to_value": -1.5,
+    "to_y": 255
+  },
+  "argument2": "minecraft:overworld/offset"
+}

--- a/Forge/src/main/resources/data/aether/worldgen/noise_settings/skylands.json
+++ b/Forge/src/main/resources/data/aether/worldgen/noise_settings/skylands.json
@@ -1,0 +1,179 @@
+{
+  "aquifers_enabled": false,
+  "default_block": {
+    "Name": "aether:holystone",
+    "Properties": {
+      "double_drops": "true"
+    }
+  },
+  "default_fluid": {
+    "Name": "minecraft:water",
+    "Properties": {
+      "level": "0"
+    }
+  },
+  "disable_mob_generation": false,
+  "legacy_random_source": false,
+  "noise": {
+    "height": 128,
+    "min_y": 0,
+    "size_horizontal": 2,
+    "size_vertical": 1
+  },
+  "noise_router": {
+    "barrier": 0.0,
+    "continents": 0.0,
+    "depth": "aeroblender:aether/depth",
+    "erosion": 0.0,
+    "final_density": {
+      "type": "minecraft:squeeze",
+      "argument": {
+        "type": "minecraft:interpolated",
+        "argument": {
+          "type": "minecraft:blend_density",
+          "argument": {
+            "type": "minecraft:add",
+            "argument1": -0.05,
+            "argument2": {
+              "type": "minecraft:add",
+              "argument1": -0.1,
+              "argument2": {
+                "type": "minecraft:mul",
+                "argument1": {
+                  "type": "minecraft:y_clamped_gradient",
+                  "from_value": 0.0,
+                  "from_y": 8,
+                  "to_value": 1.0,
+                  "to_y": 40
+                },
+                "argument2": {
+                  "type": "minecraft:add",
+                  "argument1": 0.1,
+                  "argument2": {
+                    "type": "minecraft:add",
+                    "argument1": -0.2,
+                    "argument2": {
+                      "type": "minecraft:mul",
+                      "argument1": {
+                        "type": "minecraft:y_clamped_gradient",
+                        "from_value": 1.0,
+                        "from_y": 56,
+                        "to_value": 0.0,
+                        "to_y": 128
+                      },
+                      "argument2": {
+                        "type": "minecraft:add",
+                        "argument1": 0.2,
+                        "argument2": {
+                          "type": "minecraft:add",
+                          "argument1": -0.13,
+                          "argument2": "aether:base_3d_noise_aether"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fluid_level_floodedness": 0.0,
+    "fluid_level_spread": 0.0,
+    "initial_density_without_jaggedness": 0.0,
+    "lava": 0.0,
+    "ridges": 0.0,
+    "temperature": {
+      "type": "minecraft:shifted_noise",
+      "noise": "aether:temperature",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0.0,
+      "shift_z": "minecraft:shift_z",
+      "xz_scale": 0.25,
+      "y_scale": 0.0
+    },
+    "vegetation": {
+      "type": "minecraft:shifted_noise",
+      "noise": "aether:vegetation",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0.0,
+      "shift_z": "minecraft:shift_z",
+      "xz_scale": 0.25,
+      "y_scale": 0.0
+    },
+    "vein_gap": 0.0,
+    "vein_ridged": 0.0,
+    "vein_toggle": 0.0
+  },
+  "ore_veins_enabled": false,
+  "sea_level": -64,
+  "spawn_target": [],
+  "surface_rule": {
+    "type": "minecraft:sequence",
+    "sequence": [
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:stone_depth",
+          "add_surface_depth": false,
+          "offset": 0,
+          "secondary_depth_range": 0,
+          "surface_type": "floor"
+        },
+        "then_run": {
+          "type": "minecraft:sequence",
+          "sequence": [
+            {
+              "type": "minecraft:condition",
+              "if_true": {
+                "type": "minecraft:water",
+                "add_stone_depth": false,
+                "offset": -1,
+                "surface_depth_multiplier": 0
+              },
+              "then_run": {
+                "type": "minecraft:block",
+                "result_state": {
+                  "Name": "aether:aether_grass_block",
+                  "Properties": {
+                    "double_drops": "true",
+                    "snowy": "false"
+                  }
+                }
+              }
+            },
+            {
+              "type": "minecraft:block",
+              "result_state": {
+                "Name": "aether:aether_dirt",
+                "Properties": {
+                  "double_drops": "true"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "minecraft:condition",
+        "if_true": {
+          "type": "minecraft:stone_depth",
+          "add_surface_depth": true,
+          "offset": 0,
+          "secondary_depth_range": 0,
+          "surface_type": "floor"
+        },
+        "then_run": {
+          "type": "minecraft:block",
+          "result_state": {
+            "Name": "aether:aether_dirt",
+            "Properties": {
+              "double_drops": "true"
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This pull request adds a depth parameter to the Aether, so that other addons don't need to all override the skylands noise in order to use the depth parameter and make vertical biomes