### PR TITLE
Fix incompat with Terrablender's End Backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 minecraft {
     mappings channel: 'official', version: '1.20.1'
-    //accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     runs {
         client {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ minecraft_version=1.20.1
 aether_version=1.20.1-1.0.0-neoforge
 nitrogen_version=1.20.1-1.0.1-neoforge
 cumulus_version=1.20.1-1.0.0-neoforge
-terrablender_version=1.20.1-3.0.0.169
+terrablender_version=1.20.1-3.0.1.5
 curios_version=5.3.2+1.20.1

--- a/src/main/java/teamrazor/aeroblender/AeroBlenderConfig.java
+++ b/src/main/java/teamrazor/aeroblender/AeroBlenderConfig.java
@@ -19,8 +19,6 @@ package teamrazor.aeroblender;
 
 import net.minecraftforge.common.ForgeConfigSpec;
 import org.apache.commons.lang3.tuple.Pair;
-import terrablender.config.Config;
-import terrablender.config.ConfigFile;
 
 import java.nio.file.Path;
 

--- a/src/main/java/teamrazor/aeroblender/mixin/LayeredNoiseUtilMixin.java
+++ b/src/main/java/teamrazor/aeroblender/mixin/LayeredNoiseUtilMixin.java
@@ -18,31 +18,17 @@ import java.util.function.LongFunction;
 
 @Mixin(value = LayeredNoiseUtil.class, remap = false)
 public abstract class LayeredNoiseUtilMixin {
+    @Shadow
+    public static Area createZoomedArea(long seed, int zooms, AreaTransformer0 initialTransformer) {
+        return null;
+    }
 
     @Inject(at = @At("HEAD"), method = "uniqueness", cancellable = true)
-    private static void uniqueness(RegistryAccess registryAccess, RegionType regionType, long worldSeed, CallbackInfoReturnable<Area> cir) {
-        if(regionType == AetherRegionType.THE_AETHER) {
+    private static void uniqueness(RegistryAccess registryAccess, RegionType regionType, long seed, CallbackInfoReturnable<Area> cir) {
+        if (regionType == AetherRegionType.THE_AETHER) {
             int numZooms1 = AeroBlenderConfig.COMMON.aetherRegionSize.get();
-
-            LongFunction<AreaContext> contextFactory = (seedModifier) -> new AreaContext(25, worldSeed, seedModifier);
-            AreaFactory factory = new InitialLayer(registryAccess, regionType).run(contextFactory.apply(1L));
-            factory = ZoomLayer.FUZZY.run(contextFactory.apply(2000L), factory);
-            factory = zoom(2001L, ZoomLayer.NORMAL, factory, 3, contextFactory);
-            factory = zoom(1001L, ZoomLayer.NORMAL, factory, numZooms1, contextFactory);
-            cir.setReturnValue(factory.make());
-            cir.cancel();
-        }
-    }
-
-    @Shadow
-    public static AreaFactory zoom(long seedModifier, AreaTransformer1 transformer, AreaFactory initialAreaFactory, int times, LongFunction<AreaContext> contextFactory) {
-        AreaFactory areaFactory = initialAreaFactory;
-
-        for(int i = 0; i < times; ++i) {
-            areaFactory = transformer.run(contextFactory.apply(seedModifier + (long)i), areaFactory);
+            cir.setReturnValue(createZoomedArea(seed, numZooms1, new InitialLayer(registryAccess, regionType)));
         }
 
-        return areaFactory;
     }
 }
-

--- a/src/main/java/teamrazor/aeroblender/mixin/LevelUtilsMixin.java
+++ b/src/main/java/teamrazor/aeroblender/mixin/LevelUtilsMixin.java
@@ -1,26 +1,79 @@
 package teamrazor.aeroblender.mixin;
 
-
-
-
+import com.google.common.collect.ImmutableList;
 import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import teamrazor.aeroblender.aether.AetherRegionType;
 import teamrazor.aeroblender.DimensionTypeTags;
+import teamrazor.aeroblender.aether.AetherRuleCategory;
 import terrablender.api.RegionType;
+import terrablender.api.Regions;
+import terrablender.api.SurfaceRuleManager;
+import terrablender.core.TerraBlender;
 import terrablender.util.LevelUtils;
+import terrablender.worldgen.IExtendedBiomeSource;
+import terrablender.worldgen.IExtendedNoiseGeneratorSettings;
+import terrablender.worldgen.IExtendedParameterList;
 
-@Mixin(value = LevelUtils.class, remap = false)
+@Mixin(value = LevelUtils.class)
 public abstract class LevelUtilsMixin {
+    @Shadow
+    public static boolean shouldApplyToBiomeSource(BiomeSource biomeSource) {
+        return false;
+    }
+    @Shadow
+    public static RegionType getRegionTypeForDimension(Holder<DimensionType> dimensionType) {
+        return null;
+    }
 
-    @Inject(at = @At("HEAD"), cancellable = true, method = "Lterrablender/util/LevelUtils;getRegionTypeForDimension(Lnet/minecraft/core/Holder;)Lterrablender/api/RegionType;")
+    @Inject(at = @At("HEAD"), cancellable = true, method = "Lterrablender/util/LevelUtils;getRegionTypeForDimension(Lnet/minecraft/core/Holder;)Lterrablender/api/RegionType;", remap = false)
     private static void addAether(Holder<DimensionType> dimensionType, CallbackInfoReturnable<RegionType> cir) {
         if (dimensionType.is(DimensionTypeTags.AETHER_REGIONS)) {
             cir.setReturnValue(AetherRegionType.THE_AETHER);
+        }
+    }
+
+    @Inject(at = @At(value = "HEAD"), method = "Lterrablender/util/LevelUtils;initializeBiomes(Lnet/minecraft/core/RegistryAccess;Lnet/minecraft/core/Holder;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/level/chunk/ChunkGenerator;J)V", remap = false, cancellable = true)
+    private static void initializeAetherBiomes(RegistryAccess registryAccess, Holder<DimensionType> dimensionType, ResourceKey<LevelStem> levelResourceKey, ChunkGenerator chunkGenerator, long seed, CallbackInfo ci) {
+        {
+            RegionType regionType = getRegionTypeForDimension(dimensionType);
+            if (regionType == AetherRegionType.THE_AETHER) {
+                if (shouldApplyToBiomeSource(chunkGenerator.getBiomeSource())) {
+                    NoiseBasedChunkGenerator noiseBasedChunkGenerator = (NoiseBasedChunkGenerator) chunkGenerator;
+                    NoiseGeneratorSettings generatorSettings = noiseBasedChunkGenerator.generatorSettings().value();
+                    MultiNoiseBiomeSource biomeSource = (MultiNoiseBiomeSource) chunkGenerator.getBiomeSource();
+                    IExtendedBiomeSource biomeSourceEx = (IExtendedBiomeSource) biomeSource;
+                    SurfaceRuleManager.RuleCategory ruleCategory = AetherRuleCategory.THE_AETHER;
+                    ((IExtendedNoiseGeneratorSettings) (Object) generatorSettings).setRuleCategory(ruleCategory);
+                    Climate.ParameterList parameters = biomeSource.parameters();
+                    IExtendedParameterList parametersEx = (IExtendedParameterList) parameters;
+                    parametersEx.initializeForTerraBlender(registryAccess, regionType, seed);
+                    Registry<Biome> biomeRegistry = registryAccess.registryOrThrow(Registries.BIOME);
+                    ImmutableList.Builder<Holder<Biome>> builder = ImmutableList.builder();
+                    Regions.get(regionType).forEach(region -> region.addBiomes(biomeRegistry, pair -> builder.add(biomeRegistry.getHolderOrThrow(pair.getSecond()))));
+                    biomeSourceEx.appendDeferredBiomesList(builder.build());
+                    TerraBlender.LOGGER.info(String.format("Initialized TerraBlender biomes for level stem %s", levelResourceKey.location()));
+                    ci.cancel();
+                }
+            }
         }
     }
 }

--- a/src/main/java/teamrazor/aeroblender/mixin/NoiseGeneratorSettingsMixin.java
+++ b/src/main/java/teamrazor/aeroblender/mixin/NoiseGeneratorSettingsMixin.java
@@ -5,6 +5,7 @@ import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.SurfaceRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -12,6 +13,7 @@ import teamrazor.aeroblender.Aeroblender;
 import teamrazor.aeroblender.aether.AetherRegionType;
 import teamrazor.aeroblender.aether.AetherRuleCategory;
 import terrablender.api.RegionType;
+import terrablender.api.SurfaceRuleManager;
 import terrablender.worldgen.IExtendedNoiseGeneratorSettings;
 
 @Mixin(value = NoiseGeneratorSettings.class, priority = 900)
@@ -20,13 +22,15 @@ public class NoiseGeneratorSettingsMixin implements IExtendedNoiseGeneratorSetti
     @Shadow
     private SurfaceRules.RuleSource surfaceRule;
 
-    private RegionType regionType  = null;
+    @Unique
+    private SurfaceRuleManager.RuleCategory ruleCategory = null;
 
+    @Unique
     private SurfaceRules.RuleSource namespacedSurfaceRuleSource = null;
 
    @Inject(method = "surfaceRule", at = @At("HEAD"), cancellable = true)
    private void surfaceRule(CallbackInfoReturnable<SurfaceRules.RuleSource> cir) {
-       if (this.regionType == AetherRegionType.THE_AETHER) {
+       if (this.ruleCategory == AetherRuleCategory.THE_AETHER) {
            if (this.namespacedSurfaceRuleSource == null)
                this.namespacedSurfaceRuleSource = Aeroblender.getAetherNamespacedRules(AetherRuleCategory.THE_AETHER, this.surfaceRule);
            cir.setReturnValue(this.namespacedSurfaceRuleSource);
@@ -34,14 +38,7 @@ public class NoiseGeneratorSettingsMixin implements IExtendedNoiseGeneratorSetti
    }
 
     @Override
-    public void setRegionType(RegionType regionType)
-    {
-        this.regionType = regionType;
-    }
-
-    @Override
-    public RegionType getRegionType()
-    {
-        return this.regionType ;
+    public void setRuleCategory(SurfaceRuleManager.RuleCategory ruleCategory) {
+        this.ruleCategory = ruleCategory;
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.world.level.biome.MultiNoiseBiomeSource m_274409_()Lnet/minecraft/world/level/biome/Climate$ParameterList; #parameters


### PR DESCRIPTION
Backports 893af503ba861ef539d46df53e2f7679ec5a827c. Depends on https://github.com/Glitchfiend/TerraBlender/pull/204, but we can actually use version 3.0.1.5 for building already, as that, and only that, version contains the backport code as well.

Update: Adubbz has said they'll merge the Terrablender PR if this one gets merged.